### PR TITLE
Make joinstr-rust compatible with Python reference implementation

### DIFF
--- a/rust/joinstr/Cargo.toml
+++ b/rust/joinstr/Cargo.toml
@@ -13,6 +13,7 @@ async = ["nostr-sdk", "tokio"]
 [dependencies]
 home = { workspace = true }
 backoff = { workspace = true }
+base64ct = { workspace = true, features = ["alloc"] }
 bitcoin = { workspace = true }
 bip39 = { workspace = true, features = ["rand"] }
 hex-conservative = { workspace = true }

--- a/rust/joinstr/src/coinjoin/error.rs
+++ b/rust/joinstr/src/coinjoin/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     Electrum(electrum::Error),
     FailVerifyAmount,
     AmountMissing,
+    InputValueOutOfRange(u64, u64, u64),
+    FeeBoundsViolation(u64, u64, u64),
     Unknown(String),
 }
 
@@ -64,6 +66,16 @@ impl Display for Error {
             Error::AmountMissing => write!(
                 f,
                 "The input amount is missing and no electrum client provided"
+            ),
+            Error::InputValueOutOfRange(value, min, max) => write!(
+                f,
+                "Input value {} sats is outside allowed range [{}, {}]",
+                value, min, max
+            ),
+            Error::FeeBoundsViolation(fee, min, max) => write!(
+                f,
+                "Fee {} sats is outside allowed bounds [{}, {}]",
+                fee, min, max
             ),
             Error::Unknown(e) => write!(f, "Unknown error: {}", e),
         }

--- a/rust/joinstr/src/nostr/mod.rs
+++ b/rust/joinstr/src/nostr/mod.rs
@@ -674,8 +674,10 @@ impl PoolMessage {
         let mut map = Map::new();
         match self {
             PoolMessage::Psbt(psbt) => {
-                map.insert("type".into(), "psbt".into());
-                map.insert("psbt".into(), serde_json::to_value(psbt)?);
+                map.insert("type".into(), "input".into());
+                let psbt_bytes = psbt.serialize();
+                let psbt_b64 = base64ct::Base64::encode_string(&psbt_bytes);
+                map.insert("psbt".into(), Value::String(psbt_b64));
             }
             PoolMessage::Transaction(tx) => {
                 map.insert("type".into(), "transaction".into());

--- a/rust/joinstr/tests/coinjoin.rs
+++ b/rust/joinstr/tests/coinjoin.rs
@@ -8,7 +8,7 @@ use miniscript::bitcoin::Amount;
 #[test]
 fn simple_tx() {
     let (mut signer, mut client, _electrsd, bitcoind) =
-        funded_wallet(&[0.11, 0.11, 0.11, 0.11, 0.11]);
+        funded_wallet(&[0.10003, 0.10003, 0.10003, 0.10003, 0.10003]);
 
     signer.set_client(client.clone());
 
@@ -47,7 +47,7 @@ fn simple_tx() {
 #[test]
 fn simple_coinjoin() {
     let (mut signer, mut client, _electrsd, bitcoind) =
-        funded_wallet(&[0.11, 0.11, 0.11, 0.11, 0.11]);
+        funded_wallet(&[0.10003, 0.10003, 0.10003, 0.10003, 0.10003]);
 
     signer.set_client(client.clone());
 

--- a/rust/joinstr/tests/joinstr.rs
+++ b/rust/joinstr/tests/joinstr.rs
@@ -159,7 +159,7 @@ fn simple_coinjoin() {
 
     log::info!("Received pool notification.");
 
-    let mut signer = funded_wallet_with_bitcoind(&[0.011, 0.011], &bitcoind);
+    let mut signer = funded_wallet_with_bitcoind(&[0.01003, 0.01003], &bitcoind);
     let client = Client::new(&url, port).unwrap();
     signer.set_client(client);
 


### PR DESCRIPTION
## Summary
- Pool event and message serde now matches Python wire format (BTC float denomination, string relay/transport, expanded credentials, optional version field, `new_pool` type)
- Fee/amount logic matches Python: output amount = `denomination - fee_rate * 100`, input range validation (denomination+500 to denomination+5000), fee bounds check (N*100 to N*10000)
- Input registration sends base64-encoded signed PSBT as `{"psbt": "<base64>", "type": "input"}` instead of custom InputDataSigned format
- Tests updated for new validation ranges